### PR TITLE
fix: pin eslint-plugin-n to ^15.7 to support node 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "create-aio-lib": "bin/run"
       },
       "devDependencies": {
-        "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+        "@adobe/eslint-config-aio-lib-config": "^2.0.2",
         "eslint": "^8.47.0",
         "eslint-config-oclif": "^4",
         "eslint-config-standard": "^17.1.0",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@adobe/eslint-config-aio-lib-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-aio-lib-config/-/eslint-config-aio-lib-config-2.0.1.tgz",
-      "integrity": "sha512-zDOuwSMV6UZNLYFMXpBo0UZXniCBmXCK9Qoay/jqJL/trUzJWuYPZZdFWhrERpAQ5HOks20YJDD2aKq1WwHMhQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-aio-lib-config/-/eslint-config-aio-lib-config-2.0.2.tgz",
+      "integrity": "sha512-daTwo5xEJ0bCYvblu1lJug0FKYuO2B6V47K4LgCwtXnynHuABKajSySSmFR0+gZQRwnz/ZLvuvHhjCZAmdsFWg==",
       "dev": true,
       "peerDependencies": {
         "eslint": "^8",
@@ -86,7 +86,7 @@
         "eslint-plugin-import": "^2",
         "eslint-plugin-jest": "^27",
         "eslint-plugin-jsdoc": "^42",
-        "eslint-plugin-n": "^16",
+        "eslint-plugin-n": "^15.7",
         "eslint-plugin-node": "^11",
         "eslint-plugin-promise": "^6",
         "typescript": ">=2.8.2"
@@ -8704,9 +8704,9 @@
       }
     },
     "@adobe/eslint-config-aio-lib-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-aio-lib-config/-/eslint-config-aio-lib-config-2.0.1.tgz",
-      "integrity": "sha512-zDOuwSMV6UZNLYFMXpBo0UZXniCBmXCK9Qoay/jqJL/trUzJWuYPZZdFWhrERpAQ5HOks20YJDD2aKq1WwHMhQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-aio-lib-config/-/eslint-config-aio-lib-config-2.0.2.tgz",
+      "integrity": "sha512-daTwo5xEJ0bCYvblu1lJug0FKYuO2B6V47K4LgCwtXnynHuABKajSySSmFR0+gZQRwnz/ZLvuvHhjCZAmdsFWg==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,9 @@
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-jsdoc": "^42.0.0",
-        "eslint-plugin-n": "^16.0.1",
+        "eslint-plugin-n": "^15.7",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-unicorn": "^42.0.0",
         "jest": "^29.6.2",
         "typescript": "^5.1.6"
       },
@@ -3365,23 +3364,38 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-es-x": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
-      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
+    "node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.6.0"
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": ">=8.10.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=8"
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -3510,22 +3524,22 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.1.tgz",
-      "integrity": "sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
-        "eslint-plugin-es-x": "^7.1.0",
-        "ignore": "^5.2.4",
-        "is-core-module": "^2.12.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
-        "resolve": "^1.22.2",
-        "semver": "^7.5.3"
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=12.22.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
@@ -3607,37 +3621,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-      "integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "ci-info": "^3.3.0",
-        "clean-regexp": "^1.0.0",
-        "eslint-utils": "^3.0.0",
-        "esquery": "^1.4.0",
-        "indent-string": "^4.0.0",
-        "is-builtin-module": "^3.1.0",
-        "lodash": "^4.17.21",
-        "pluralize": "^8.0.0",
-        "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.24",
-        "safe-regex": "^2.1.1",
-        "semver": "^7.3.5",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.8.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -6850,15 +6833,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8080,18 +8054,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -11344,14 +11306,25 @@
         }
       }
     },
-    "eslint-plugin-es-x": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
-      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
+    "eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.6.0"
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -11442,19 +11415,19 @@
       }
     },
     "eslint-plugin-n": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.1.tgz",
-      "integrity": "sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
-        "eslint-plugin-es-x": "^7.1.0",
-        "ignore": "^5.2.4",
-        "is-core-module": "^2.12.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
-        "resolve": "^1.22.2",
-        "semver": "^7.5.3"
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       }
     },
     "eslint-plugin-node": {
@@ -11504,28 +11477,6 @@
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
       "dev": true,
       "requires": {}
-    },
-    "eslint-plugin-unicorn": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-      "integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "ci-info": "^3.3.0",
-        "clean-regexp": "^1.0.0",
-        "eslint-utils": "^3.0.0",
-        "esquery": "^1.4.0",
-        "indent-string": "^4.0.0",
-        "is-builtin-module": "^3.1.0",
-        "lodash": "^4.17.21",
-        "pluralize": "^8.0.0",
-        "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.24",
-        "safe-regex": "^2.1.1",
-        "semver": "^7.3.5",
-        "strip-indent": "^3.0.0"
-      }
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -13702,12 +13653,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -14572,15 +14517,6 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
-    },
-    "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "requires": {
-        "min-indent": "^1.0.0"
-      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "listr2": "^6.6.0"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+    "@adobe/eslint-config-aio-lib-config": "^2.0.2",
     "eslint": "^8.47.0",
     "eslint-config-oclif": "^4",
     "eslint-config-standard": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-jsdoc": "^42.0.0",
-    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.6.2",


### PR DESCRIPTION
## Description

Version `^16.0` of `eslint-plugin-n` doesn't support Node 14, but `aio` still does. Pin to `^15.7` for now

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
